### PR TITLE
Add instrumentation for ActionController::Live#send_stream

### DIFF
--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -125,6 +125,7 @@ module ActionController
       DataStreaming,
       DefaultHeaders,
       Logging,
+      Live,
 
       # Before callbacks should also be executed as early as possible, so
       # also include them at the bottom.

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -221,6 +221,7 @@ module ActionController
       HttpAuthentication::Token::ControllerMethods,
       DefaultHeaders,
       Logging,
+      Live,
 
       # Before callbacks should also be executed as early as possible, so
       # also include them at the bottom.

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -44,6 +44,13 @@ module ActionController
       end
     end
 
+    def send_stream(filename:, disposition: "attachment", type: nil)
+      payload = { filename: filename, disposition: disposition, type: type }
+      ActiveSupport::Notifications.instrument("send_stream.action_controller", payload) do
+        super
+      end
+    end
+
     def redirect_to(*)
       ActiveSupport::Notifications.instrument("redirect_to.action_controller", request: request) do |payload|
         result = super

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
+*   Add instrumentation for ActionController::Live#send_stream
+
+    Allows subscribing to `send_stream` events. The event payload contains the filename, disposition, and type.
+
+    *Hannah Ramadan*
+
 *   Add `drb`, `mutex_m` and `base64` that are bundled gem candidates for Ruby 3.4
 
     *Yasuo Honda*


### PR DESCRIPTION
### Motivation / Background

It was great to see `ActionController::Live#send_stream` introduced in Rails 7.0. We'd like to collect information on `send_stream` events by adding instrumentation for it.

### Detail

Adds instrumentation for `ActionController::Live#send_stream`. The event payload contains the filename, disposition, and type.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
